### PR TITLE
Add permission for fsserver to write/delete socket files

### DIFF
--- a/roles/openafs_server/templates/openafs.te.j2
+++ b/roles/openafs_server/templates/openafs.te.j2
@@ -11,6 +11,7 @@ require {
 	type usr_t;
 	class unix_stream_socket connectto;
 	class lnk_file create;
+    class sock_file { unlink write };
 	class file { create getattr lock open read setattr write };
 	class dir { add_name create read write search };
 }
@@ -24,6 +25,7 @@ allow afs_bosserver_t afs_config_t:lnk_file create;
 
 #============= afs_fsserver_t ==============
 allow afs_fsserver_t self:unix_stream_socket connectto;
+allow afs_fsserver_t afs_config_t:sock_file { unlink write };
 
 #============= afs_ptserver_t ==============
 allow afs_ptserver_t afs_files_t:dir search;

--- a/roles/openafs_server/vars/CentOS.yaml
+++ b/roles/openafs_server/vars/CentOS.yaml
@@ -7,4 +7,4 @@ afsdbdir: /usr/afs/db
 afslogdir: /usr/afs/logs
 
 # SELinux module version
-selinux_openafs_version: 1.0
+selinux_openafs_version: 1.1


### PR DESCRIPTION
Found this permission was needed when restarting ansible playbook.  