### PR TITLE
Set services to restart at boot time

### DIFF
--- a/roles/kerberos_server/tasks/main.yaml
+++ b/roles/kerberos_server/tasks/main.yaml
@@ -32,11 +32,13 @@
 - name: Start kerberos kdc
   service:
     name: krb5kdc
+    enabled: yes
     state: started
 
 - name: Start kadmin
   service:
     name: kadmin
+    enabled: yes
     state: started
 
 - name: Create admin principal

--- a/roles/openafs_client/tasks/main.yaml
+++ b/roles/openafs_client/tasks/main.yaml
@@ -11,4 +11,5 @@
 - name: Start OpenAFS client
   service:
     state: started
+    enabled: yes
     name: openafs-client

--- a/roles/openafs_server/tasks/redhat/post-config.yaml
+++ b/roles/openafs_server/tasks/redhat/post-config.yaml
@@ -18,3 +18,4 @@
   service:
     name: openafs-server
     state: started
+    enabled: yes


### PR DESCRIPTION
Sets the krb5kdc, kadmin,, openafs-server and openafs-client services to restart at system boot time