### PR TITLE
openafs_client install-build: Fix rsync command

### DIFF
--- a/roles/openafs_client/tasks/redhat/install-build.yaml
+++ b/roles/openafs_client/tasks/redhat/install-build.yaml
@@ -85,7 +85,7 @@
     state: absent
 
 - name: Install files
-  command: rsync -av * /
+  command: rsync -av ./ /
   args:
     chdir: /tmp/openafs-client-build
 


### PR DESCRIPTION
Correct the parameters for rsync.