### PR TITLE
Centos8 support

### DIFF
--- a/roles/openafs_client/tasks/dnf-dkms.yaml
+++ b/roles/openafs_client/tasks/dnf-dkms.yaml
@@ -1,0 +1,1 @@
+yum-dkms.yaml

--- a/roles/openafs_client/tasks/dnf-kmod.yaml
+++ b/roles/openafs_client/tasks/dnf-kmod.yaml
@@ -1,0 +1,1 @@
+yum-kmod.yaml

--- a/roles/openafs_client/tasks/install-dnf.yaml
+++ b/roles/openafs_client/tasks/install-dnf.yaml
@@ -1,0 +1,1 @@
+install-yum.yaml

--- a/roles/openafs_client/tasks/post-rsync-redhat.yaml
+++ b/roles/openafs_client/tasks/post-rsync-redhat.yaml
@@ -1,4 +1,10 @@
 ---
+
+# Patch up the contexts for the directories and files
+# that were created while in unconfined_t
+- name: Restore directory contexts for selinux
+  command: restorecon -ir /lib/modules
+
 - name: Install module probe script
   copy:
     src: "{{ role_path }}/files/{{ ansible_os_family|lower }}/openafs-client.modules"

--- a/roles/openafs_devel/tasks/install-dnf.yaml
+++ b/roles/openafs_devel/tasks/install-dnf.yaml
@@ -1,0 +1,1 @@
+install-yum.yaml

--- a/roles/openafs_devel/tasks/install-yum.yaml
+++ b/roles/openafs_devel/tasks/install-yum.yaml
@@ -35,3 +35,11 @@
     name:
       - kernel-devel
   when: afs_devel_build_client | bool
+
+- name: Install kernel devel packages
+  yum:
+    state: present
+    name:
+      - elfutils-devel
+  when: afs_devel_build_client | bool and (ansible_distribution == "CentOS" and ansible_distribution_major_version >= "8")
+

--- a/roles/openafs_krbclient/tasks/install-dnf.yaml
+++ b/roles/openafs_krbclient/tasks/install-dnf.yaml
@@ -1,0 +1,1 @@
+install-yum.yaml

--- a/roles/openafs_krbserver/tasks/install-dnf.yaml
+++ b/roles/openafs_krbserver/tasks/install-dnf.yaml
@@ -1,0 +1,1 @@
+install-yum.yaml

--- a/roles/openafs_server/tasks/install-dnf.yaml
+++ b/roles/openafs_server/tasks/install-dnf.yaml
@@ -1,0 +1,1 @@
+install-yum.yaml

--- a/roles/openafs_server/tasks/selinux-policies.yaml
+++ b/roles/openafs_server/tasks/selinux-policies.yaml
@@ -5,6 +5,7 @@
       - policycoreutils-python
       - setools-console
     state: present
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version < "8"
 
 - name: Test for presence of openafs module in SELinux
   shell: semodule -lstandard | grep -E '^openafs\s+{{ afs_selinux_openafs_version }}$'


### PR DESCRIPTION
openafs_server: setools already installed as part of the base OS
openafs_client: need to perform restorecon for /lib/module (to pick up
                openafs.ko)
openafs_devel: need to install elfutils-devel (kernel module build
               prereq)

symlinks for *yum*.yaml -> *dnf*.yaml