### PR TITLE
Fix rsync to not remove symlinked directories

### DIFF
--- a/roles/openafs_client/tasks/install-rsync.yaml
+++ b/roles/openafs_client/tasks/install-rsync.yaml
@@ -19,7 +19,7 @@
   when: afs_client_build_force|bool or not destdir_st.stat.exists
 
 - name: Install dest directory to system
-  command: rsync -a --info=name --checksum . /
+  command: rsync -a -K --info=name --checksum . /
   args:
     chdir: "{{ afs_client_build_destdir }}"
   register: rsync_results

--- a/roles/openafs_server/tasks/install-rsync.yaml
+++ b/roles/openafs_server/tasks/install-rsync.yaml
@@ -20,7 +20,7 @@
   when: afs_server_build_force|bool or not destdir_st.stat.exists
 
 - name: Install dest directory to system
-  command: rsync -a --info=name --checksum . /
+  command: rsync -a -K --info=name --checksum . /
   args:
     chdir: "{{ afs_server_build_destdir }}"
   register: rsync_results


### PR DESCRIPTION
If a target directory is a symlink and the source directory is not,
rsync will remove the symlink and create a "real" directory.  This can
cause problems (e.g. on centos /lib is a symlink to /usr/lib).

Rsync has an option (-K) that treats any target symlinked directory as a
real directory.