### PR TITLE
openafs_robotest - Make distro independent

### DIFF
--- a/roles/openafs_robotest/tasks/install-packages-redhat.yaml
+++ b/roles/openafs_robotest/tasks/install-packages-redhat.yaml
@@ -13,3 +13,9 @@
       - git
       - python-pip
     state: present
+
+- name: Install Robot Framework OpenAFS library
+  become: yes
+  pip:
+    name: robotframework-openafslibrary
+    state: present

--- a/roles/openafs_robotest/tasks/main.yaml
+++ b/roles/openafs_robotest/tasks/main.yaml
@@ -23,12 +23,6 @@
     name: "{{ afs_robotest_user }}"
     shell: /bin/bash
 
-- name: Install Robot Framework OpenAFS library
-  become: yes
-  pip:
-    name: robotframework-openafslibrary
-    state: present
-
 - name: Download OpenAFS test cases
   become: yes
   become_user: "{{ afs_robotest_user }}"

--- a/roles/openafs_robotest/templates/local.py.j2
+++ b/roles/openafs_robotest/templates/local.py.j2
@@ -1,8 +1,8 @@
 # Realm
-KRB_REALM = 'EXAMPLE.COM'
+KRB_REALM = '{{ afs_realm }}'
 
 # Cell
-AFS_CELL = 'example.com'
+AFS_CELL = '{{ afs_cell }}'
 AFS_USER = 'user1'
 AFS_ADMIN = 'admin'
 AFS_AKIMPERSONATE = False


### PR DESCRIPTION
Move pip install of robotframework-openafslibrary into distro specific
task

Remove hardcoded cell/realm from file templates.