### PR TITLE
Use afs_all instead of all for host

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -44,20 +44,22 @@ TODO: Describe
     cat ~/inventories/hosts
     [afs_kdcs]
     afs01.example.com
-    
+
     [afs_databases]
     afs01.example.com
     afs02.example.com
     afs03.example.com
-    
+
     [afs_fileservers]
     afs04.example.com
     afs05.example.com
     afs06.example.com
-    
+
     [afs_clients]
     afs[01:06].example.com
 
+    [afs_cell]
+    afs[01:06].example.com
 
     cat ~/inventories/example.com/group_vars/all.yaml
     ---

--- a/playbooks/cell.yaml
+++ b/playbooks/cell.yaml
@@ -3,7 +3,7 @@
 # Playbook to deploy an OpenAFS cell.
 #
 - name: Wait for guests to start
-  hosts: all
+  hosts: afs_cell
   gather_facts: no
   tasks:
   - name: Wait for system to become reachable

--- a/playbooks/realm.yaml
+++ b/playbooks/realm.yaml
@@ -3,7 +3,7 @@
 # Deploy kerberos realm.
 #
 - name: Wait for guests to start
-  hosts: all
+  hosts: afs_cell
   gather_facts: no
   tasks:
   - name: Wait for system to become reachable
@@ -17,7 +17,7 @@
     - openafs_krbserver
 
 - name: Install Kerberos clients
-  hosts: all
+  hosts: afs_cell
   become: yes
   any_errors_fatal: true
   roles:

--- a/playbooks/testcell.yaml
+++ b/playbooks/testcell.yaml
@@ -3,7 +3,7 @@
 # Playbook to deploy an OpenAFS cell.
 #
 - name: Wait for guests to start
-  hosts: all
+  hosts: afs_cell
   gather_facts: no
   tasks:
   - name: Wait for system to become reachable
@@ -17,7 +17,7 @@
     - openafs_krbserver
 
 - name: Install Kerberos clients
-  hosts: all
+  hosts: afs_cell
   become: yes
   any_errors_fatal: true
   roles:


### PR DESCRIPTION
Add an additional group the represents just the afs related hosts.  This
allows the inventory to include hosts that are not related to afs.