### PR TITLE
improve handling keytab and keyfiles

### DIFF
--- a/roles/openafs_krbclient/templates/krb5.conf.j2
+++ b/roles/openafs_krbclient/templates/krb5.conf.j2
@@ -2,7 +2,8 @@
 
 [libdefaults]
     default_realm = {{ afs_realm }}
-
+    allow_weak_crypto = true
+    
 [realms]
     {{ afs_realm }} = {
 {% if afs_kdc_servers is defined %}

--- a/roles/openafs_krbserver/templates/krb5.conf.j2
+++ b/roles/openafs_krbserver/templates/krb5.conf.j2
@@ -2,7 +2,8 @@
 
 [libdefaults]
     default_realm = {{ afs_realm }}
-
+    allow_weak_crypto = true
+    
 [realms]
     {{ afs_realm }} = {
 {% for host in groups['afs_kdcs'] %}

--- a/roles/openafs_server/README.md
+++ b/roles/openafs_server/README.md
@@ -18,6 +18,9 @@ description.
 
     afs_admin_principal:
     afs_admin_password: (undefined by default)
+    afs_servicekey_options:
+      - additional options passed to kadmin when creating the principal associated with the
+        service key (can be used to specify the encryption type).  Default is blank.
 
 A administrator principal and password to be used to set the AFS service key.
 The password is not defined by default and must be set on the command line (-e)

--- a/roles/openafs_server/tasks/create-service-key.yaml
+++ b/roles/openafs_server/tasks/create-service-key.yaml
@@ -1,0 +1,51 @@
+---
+# Create the service key and 
+
+- name: Create the afs service principal
+  become: yes
+  command: >
+    {{ afs_kadmin }}
+    -w {{ afs_admin_password }}
+    -p {{ afs_admin_principal }}@{{ afs_realm }}
+    -r "{{ afs_realm }}"
+    -q "add_principal {{ afs_servicekey_options | default('') }} -randkey afs/{{ afs_cell }}@{{ afs_realm }}"
+  register: kadmin_results
+  changed_when: >
+    kadmin_results.rc == 0
+    and not "already exists while creating" in kadmin_results.stderr
+  when: inventory_hostname == ansible_play_hosts[0]
+
+- name: Check for existance of the service key
+  local_action: stat path="{{ afs_local_dir }}/rxkad.keytab.ansible"
+  register: afs_service_key
+
+- name: Write the service key to a keytab file
+  become: yes
+  command: >
+    {{ afs_kadmin }}
+    -r "{{ afs_realm }}"
+    -p "{{ afs_admin_principal }}"
+    -w "{{ afs_admin_password }}"
+    -q 'ktadd -norandkey -k rxkad.keytab.ansible afs/{{ afs_cell }}@{{ afs_realm }}'
+  args:
+    creates: "{{ afs_afsconfdir }}/rxkad.keytab.ansible"
+  when: (kadmin_results.rc == 0 
+        or not afs_service_key.stat.exists) 
+        and inventory_hostname == ansible_play_hosts[0]
+
+- name: Retrieve Service key to controller
+  become: yes
+  fetch:
+    flat: yes
+    src: rxkad.keytab.ansible
+    dest: "{{ afs_local_dir }}/rxkad.keytab.ansible"
+  when: (kadmin_results.rc == 0 
+        or not afs_service_key.stat.exists) 
+        and inventory_hostname == ansible_play_hosts[0]
+
+- name: Cleanup service key
+  become: yes
+  file: 
+    path: rxkad.keytab.ansible
+    state: absent  
+  when: inventory_hostname == ansible_play_hosts[0]

--- a/roles/openafs_server/tasks/main.yaml
+++ b/roles/openafs_server/tasks/main.yaml
@@ -16,6 +16,14 @@
     state: directory
     mode: 0755
 
+- name: Check for existance of the service key
+  local_action: stat path="{{ afs_local_dir }}/rxkad.keytab.ansible"
+  register: afs_service_key
+
+- name: Create service key if needed
+  include_tasks: create-service-key.yaml
+  when: not afs_service_key.stat.exists
+
 - name: Generate cell configuration files
   run_once: true
   delegate_to: localhost
@@ -26,20 +34,6 @@
     - CellServDB
     - ThisCell
     - UserList
-
-- name: Create the Kerberos service key
-  become: yes
-  command: >
-    {{ afs_kadmin }}
-    -w {{ afs_admin_password }}
-    -p {{ afs_admin_principal }}@{{ afs_realm }}
-    -r "{{ afs_realm }}"
-    -q "add_principal -randkey afs/{{ afs_cell }}@{{ afs_realm }}"
-  register: kadmin_results
-  changed_when: >
-    kadmin_results.rc == 0
-    and not "already exists while creating" in kadmin_results.stderr
-  when: inventory_hostname == ansible_play_hosts[0]
 
 # Debian based systems add a loopback address for the hostname as
 # a fallback when dns is unavailable. These can cause issues when

--- a/roles/openafs_server/tasks/server-key.yaml
+++ b/roles/openafs_server/tasks/server-key.yaml
@@ -5,16 +5,14 @@
 # supported here.  We also assume the kadmin tool is new enough to support the
 # -norandkey option to distribute the keys.
 
-- name: Write the service key to a keytab file
+- name: Copy service key
   become: yes
-  command: >
-    {{ afs_kadmin }}
-    -r "{{ afs_realm }}"
-    -p "{{ afs_admin_principal }}"
-    -w "{{ afs_admin_password }}"
-    -q 'ktadd -norandkey -k {{ afs_afsconfdir }}/rxkad.keytab.ansible afs/{{ afs_cell }}@{{ afs_realm }}'
-  args:
-    creates: "{{ afs_afsconfdir }}/rxkad.keytab.ansible"
+  copy:
+    src:  "{{ afs_local_dir }}/rxkad.keytab.ansible"
+    dest: "{{ afs_afsconfdir }}/rxkad.keytab.ansible"
+    mode: 0700
+    owner: root
+    group: root
 
 - name: Check for key value changes
   become: yes
@@ -23,17 +21,16 @@
     dest: "{{ afs_afsconfdir }}/rxkad.keytab"
     remote_src: yes
   register: keytab
-  notify:
-    - Restart OpenAFS servers
-
+  
 - name: Check for akeyconvert availability
   stat:
-    path: "{{ afs_akeyconvert }}"
-  register: akeyconvert
+    path: "{{ afs_asetkey }}"
+  register: asetkey
   changed_when: False
 
 - name: Set the service key
   become: yes
-  command: "{{ afs_akeyconvert }}"
-  register: akeyconvert_results
-  when: keytab.changed and akeyconvert.stat.exists
+  command: "{{ afs_asetkey }} add 1 {{ afs_afsconfdir }}/rxkad.keytab afs/{{ afs_cell }}" 
+  when: keytab.changed and asetkey.stat.exists
+  notify:
+    - Restart OpenAFS servers


### PR DESCRIPTION
- Support being able to use DES keys
   Add allow_weak_crypto option to krb5 conf files
   Add a new variable "afs_servicekey_options" that is passed to kadmin
   when creating the service key principal so the encryption type can
   be passed
- Create the servicekey once and propagate it to the servers