### PR TITLE
Remove LIBVIRT_DEFAULT_URI from cookiecutter destroy

### DIFF
--- a/cookiecutter/molecule-scenario/{{cookiecutter.name}}/destroy.yml
+++ b/cookiecutter/molecule-scenario/{{cookiecutter.name}}/destroy.yml
@@ -28,8 +28,6 @@
         sshdir: "{{ molecule_ephemeral_directory }}"
         logfile: "{{ molecule_yml.driver.options.logfile | default(omit) }}"
         loglevel: "{{ molecule_yml.driver.options.loglevel | default(omit) }}"
-      environment:
-        LIBVIRT_DEFAULT_URI: "{{ molecule_yml.driver.options.libvirt_uri | default('qemu:///session') }}"
       loop: "{{ molecule_yml.platforms }}"
       register: virt_up
 {%- endraw %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ molecule
 ansible
 pyflakes
 pytest
+rich < 9.5.0


### PR DESCRIPTION
The LIBVIRT_DEFAULT_URI is nolonger used.