### PR TITLE
server: add afs_service_keytab_externally_managed option

### DIFF
--- a/roles/openafs_server/defaults/main.yaml
+++ b/roles/openafs_server/defaults/main.yaml
@@ -2,6 +2,7 @@
 # The Kerberos keytab for AFS service on the controller to be uploaded to
 # the servers.
 afs_service_keytab: "{{ afs_cell_files }}/afs.{{ afs_cell }}.keytab"
+afs_service_keytab_externally_managed: false
 
 # Is this host a fileserver?
 afs_is_fileserver: "{{ 'afs_fileservers' in group_names }}"

--- a/roles/openafs_server/tasks/post-install/server-key.yaml
+++ b/roles/openafs_server/tasks/post-install/server-key.yaml
@@ -7,6 +7,8 @@
     mode: 0600
     owner: root
     group: root
+  when:
+    - not afs_service_keytab_externally_managed | bool
 
 - name: Add service keys
   become: yes


### PR DESCRIPTION
This allows the operator to have his own way of managing keytabs, such
as an integration with a secrets management tool.