### PR TITLE
Improvement for Developer Studio on Solaris

### DIFF
--- a/plugins/modules/openafs_build.py
+++ b/plugins/modules/openafs_build.py
@@ -562,6 +562,8 @@ def main():
     solariscc = lookup_fact('solariscc')
     if solariscc:
         os.environ['SOLARISCC'] = solariscc
+        os.environ['UT_NO_USAGE_TRACKING'] = '1'
+        os.environ['SUNW_NO_UPDATE_NOTIFY'] = '1'
 
     #
     # Clean previous build.

--- a/roles/openafs_devel/tasks/install/Solaris-11.4.yaml
+++ b/roles/openafs_devel/tasks/install/Solaris-11.4.yaml
@@ -79,12 +79,14 @@
     path: /usr/bin/cc
   tags: root
 
-- name: "Solaris 11.4: Set the SOLARISCC environment variable"
+- name: "Solaris 11.4: Set the SOLARISCC environment variable & disable Developer Studio check_update"
   become: yes
-  lineinfile:
+  blockinfile:
     path: /etc/profile
-    line: SOLARISCC={{ ansible_local.openafs.solariscc }}; export SOLARISCC
-    state: present
+    block: |
+      SOLARISCC={{ ansible_local.openafs.solariscc }}; export SOLARISCC
+      UT_NO_USAGE_TRACKING=1; export UT_NO_USAGE_TRACKING
+      SUNW_NO_UPDATE_NOTIFY=1; export SUNW_NO_UPDATE_NOTIFY
   tags: root
 
 # This task is a work around. The perl-526 package installation sometimes fails


### PR DESCRIPTION
When using the Developer Studio compiler an update process is
consuming significant CPU resources:
/opt/developerstudio12.6/lib/compilers/condev/bin/check_update
This can be disabled via 2 env-variables:
  - UT_NO_USAGE_TRACKING
  - SUNW_NO_UPDATE_NOTIFY