### PR TITLE
Adding environment with values from configure_env variable

### DIFF
--- a/roles/openafs_client/tasks/install/source.yaml
+++ b/roles/openafs_client/tasks/install/source.yaml
@@ -74,6 +74,7 @@
         transarc_paths: "{{ afs_transarc_build }}"
         configure_options: "{{ afs_configure_options | default(omit) }}"
       register: build_results
+      environment: "{{ configure_env | default({}) }}"
 
     - name: Build results
       debug:

--- a/roles/openafs_server/tasks/build/all.yaml
+++ b/roles/openafs_server/tasks/build/all.yaml
@@ -20,6 +20,7 @@
     transarc_paths: "{{ afs_transarc_build }}"
     configure_options: "{{ afs_configure_options | default(omit) }}"
   register: build_results
+  environment: "{{ configure_env | default({}) }}"
 
 - name: Build results
   debug:

--- a/roles/openafs_server/tasks/build/nolibafs.yaml
+++ b/roles/openafs_server/tasks/build/nolibafs.yaml
@@ -13,6 +13,7 @@
     transarc_paths: "{{ afs_transarc_build }}"
     configure_options: "{{ afs_nolibafs_configure_options | default(omit) }}"
   register: build_results
+  environment: "{{ configure_env | default({}) }}"
 
 - name: Build results
   debug:


### PR DESCRIPTION
When building from source it is possible to define variables
to fine-tune directories. Directory variables which start with afs
cannot be configured via passing flags to configure command.

For example:
  afslocaldir=SOMEPATH
  afslogsdir=ANOTHERPATH

Note: default(omit) will produce a warning if configure_env is not
defined:
[WARNING]: could not parse environment value, skipping: ['{{ configure_env | default(omit) }}']

With default({}) no warning will be created.