### PR TITLE
Enable specific repo CRB in RHEL9 distros

### DIFF
--- a/roles/openafs_devel/tasks/install/AlmaLinux-9.yaml
+++ b/roles/openafs_devel/tasks/install/AlmaLinux-9.yaml
@@ -1,0 +1,39 @@
+---
+- name: "AlmaLinux-9: Add EPEL repository"
+  become: yes
+  yum:
+    state: present
+    name: epel-release
+    update_cache: yes
+  tags: root
+
+- name: "AlmaLinux-9: Install development packages (with enabled CRB 'Code Ready Builder' repo)"
+  become: yes
+  yum:
+    state: present
+    enablerepo: crb
+    name:
+      - autoconf
+      - automake
+      - bison
+      - elfutils-devel
+      - flex
+      - fuse-devel
+      - gcc
+      - git
+      - glibc-devel
+      - jansson-devel
+      - krb5-devel
+      - libevent-devel
+      - libtool
+      - make
+      - ncurses-devel
+      - openssl-devel
+      - pam-devel
+      - perl-devel
+      - perl-ExtUtils-Embed
+      - redhat-rpm-config
+      - rpm-build
+      - swig
+      - wget
+  tags: root

--- a/roles/openafs_devel/tasks/install/CentOS-9.yaml
+++ b/roles/openafs_devel/tasks/install/CentOS-9.yaml
@@ -1,0 +1,39 @@
+---
+- name: "CentOS-9: Add EPEL repository"
+  become: yes
+  yum:
+    state: present
+    name: epel-release
+    update_cache: yes
+  tags: root
+
+- name: "CentOS-9: Install development packages (with enabled CRB 'Code Ready Builder' repo)"
+  become: yes
+  yum:
+    state: present
+    enablerepo: crb
+    name:
+      - autoconf
+      - automake
+      - bison
+      - elfutils-devel
+      - flex
+      - fuse-devel
+      - gcc
+      - git
+      - glibc-devel
+      - jansson-devel
+      - krb5-devel
+      - libevent-devel
+      - libtool
+      - make
+      - ncurses-devel
+      - openssl-devel
+      - pam-devel
+      - perl-devel
+      - perl-ExtUtils-Embed
+      - redhat-rpm-config
+      - rpm-build
+      - swig
+      - wget
+  tags: root

--- a/roles/openafs_devel/tasks/install/RedHat-9.yaml
+++ b/roles/openafs_devel/tasks/install/RedHat-9.yaml
@@ -1,0 +1,39 @@
+---
+- name: "RedHat: Add EPEL repository"
+  become: yes
+  yum:
+    state: present
+    name: epel-release
+    update_cache: yes
+  tags: root
+
+- name: "RedHat: Install development packages (with enabled CRB 'Code Ready Builder' repo)"
+  become: yes
+  yum:
+    state: present
+    enablerepo: codeready-builder-for-rhel-9-x86_64-rpms
+    name:
+      - autoconf
+      - automake
+      - bison
+      - elfutils-devel
+      - flex
+      - fuse-devel
+      - gcc
+      - git
+      - glibc-devel
+      - jansson-devel
+      - krb5-devel
+      - libevent-devel
+      - libtool
+      - make
+      - ncurses-devel
+      - openssl-devel
+      - pam-devel
+      - perl-devel
+      - perl-ExtUtils-Embed
+      - redhat-rpm-config
+      - rpm-build
+      - swig
+      - wget
+  tags: root


### PR DESCRIPTION
Additional repo for development is included in newer RedHat distributions.
This was the PowerTools repo in the past.

Since Redhat9 swig packages is moved to this repo.
Therefore we need to enable it when installing such packages.