### PR TITLE
Add yum as a RPM package manager

### DIFF
--- a/plugins/modules/openafs_get_install_paths.py
+++ b/plugins/modules/openafs_get_install_paths.py
@@ -298,7 +298,7 @@ class RpmInstallationFactCollector(InstallationFactCollector):
     """
     RPM package manager specific collection methods.
     """
-    pkg_mgrs = ['rpm', 'dnf', 'zypper']
+    pkg_mgrs = ['rpm', 'dnf', 'yum', 'zypper']
 
     def __init__(self, module):
         super(RpmInstallationFactCollector, self).__init__(module)


### PR DESCRIPTION
This fixes a failure when using afs_install_method packages and the host system is still using yum instead of dnf.